### PR TITLE
Potential fix for code scanning alert no. 35: Wrong type of arguments to formatting function

### DIFF
--- a/dse/importer/importer.c
+++ b/dse/importer/importer.c
@@ -117,7 +117,7 @@ static void _apply_samples(CsvDesc* c, double simulation_time)
                 vector_at(&c->index, idx, &signal);
                 if (signal) *signal = v;
             } else {
-                _log("Error decoding sample [%f][%u]", c->timestamp, idx);
+                _log("Error decoding sample [%f][%zu]", c->timestamp, idx);
             }
             /* Check limit. */
             if (++idx >= vector_len(&c->index)) break;


### PR DESCRIPTION
Potential fix for [https://github.com/boschglobal/dse.fmi/security/code-scanning/35](https://github.com/boschglobal/dse.fmi/security/code-scanning/35)

Use the correct `printf` format specifier for `size_t` in the `_log` call at line 120.

Best fix (no behavior change except correctness/portability):
- In `dse/importer/importer.c`, update the format string from `[%f][%u]` to `[%f][%zu]`.
- No additional imports or helper methods are required.
- This preserves logging behavior while making the argument type match the specifier across platforms.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
