### PR TITLE
Potential fix for code scanning alert no. 36: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/extra/tools/fmi/pkg/file/operations/operations.go
+++ b/extra/tools/fmi/pkg/file/operations/operations.go
@@ -29,10 +29,10 @@ func Unzip(filename string, dest string) error {
 
 	for _, file := range archive.File {
 		cleanName := filepath.Clean(file.Name)
-		filePath := filepath.Join(destAbs, cleanName)
+		filePath := filepath.Clean(filepath.Join(destAbs, cleanName))
 
-		rel, err := filepath.Rel(destAbs, filePath)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		destPrefix := destAbs + string(os.PathSeparator)
+		if filePath != destAbs && !strings.HasPrefix(filePath, destPrefix) {
 			return fmt.Errorf("UNZIP (illegal file path %q)", file.Name)
 		}
 


### PR DESCRIPTION
Potential fix for [https://github.com/boschglobal/dse.fmi/security/code-scanning/36](https://github.com/boschglobal/dse.fmi/security/code-scanning/36)

Use a strict canonical destination-boundary check before any filesystem operation on archive entries:

- Compute a canonical target path from `destAbs` + entry name.
- Ensure the resulting path is **within** `destAbs` by verifying either exact equality to `destAbs` or prefix `destAbs + os.PathSeparator`.
- Reject absolute/escaping entries that fail this check.

In `extra/tools/fmi/pkg/file/operations/operations.go`, update the path validation logic in `Unzip` (around lines 31–37). Keep existing behavior otherwise. No new dependencies are required; existing imports already include `strings`, `os`, and `filepath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
